### PR TITLE
fix: use sed instead of cargo-edit

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -82,8 +82,8 @@ jobs:
           override: true
       - name: Install latest version of dependencies
         run: |
-          cargo install cargo-edit
-          cargo add https://github.com/ipld/libipld
+          # Switch from the released version to master branch
+          sed -i 's/^libipld.*/libipld = { git = "https:\/\/github.com\/ipld\/libipld" }/' Cargo.toml
       - name: Rust information
         run: |
           cargo --version


### PR DESCRIPTION
Using cargo-edit to switch from the released version to current HEAD
lead to errors, hence use sed instead.