### PR TITLE
chore: ci: also run Rust codecs on the latest released version

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -69,6 +69,9 @@ jobs:
         rust-version:
           - stable
           - nightly
+        manifest:
+          - Cargo.toml
+          - Cargo_latest_git.toml
     defaults:
       run:
         working-directory: rust
@@ -80,14 +83,13 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust-version }}
           override: true
-      - name: Install latest version of dependencies
-        run: |
-          # Switch from the released version to master branch
-          sed -i 's/^\(libipld = { \)version = ".*",\(.*\)/\1git = "https:\/\/github.com\/ipld\/libipld",\2/' Cargo.toml
-          sed -i 's/^serde_ipld_dagcbor.*/serde_ipld_dagcbor = { git = "https:\/\/github.com\/ipld\/serde_ipld_dagcbor" }/' Cargo.toml
-      - name: Rust information
+      # The manifest file needs to be named `Cargo.toml`, hence rename if needed.
+      - name: Use specified manifest file ${{ matrix.manifest }}
+        if: matrix.manifest != 'Cargo.toml'
+        run: mv ${{ matrix.manifest }} Cargo.toml
+      - name: Rust information with ${{ matrix.manifest }}
         run: |
           cargo --version
           cargo tree
-      - name: Run tests
+      - name: Run tests with ${{ matrix.manifest }}
         run: cargo test -- --nocapture

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-libipld = { version = "0.13.0", features = ["serde-codec"] }
-serde_ipld_dagcbor = "0.2.0"
+libipld = { version = "*", features = ["serde-codec"] }
+serde_ipld_dagcbor = "*"

--- a/rust/Cargo_latest_git.toml
+++ b/rust/Cargo_latest_git.toml
@@ -1,0 +1,8 @@
+[package]
+name = "codec-fixtures"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libipld = { git = "https://github.com/ipld/libipld", features = ["serde-codec"] }
+serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor" }


### PR DESCRIPTION
Previously tests were only run on the master branches, now they
also run on the latest released versions.

Closes #50.