### PR TITLE
Negative fixtures framework (Go & JS), and negative fixtures for dag-pb!

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,31 @@ The [_fixtures_src](./_fixtures_src/) directory contains the source of each of f
 
 Fixture generation uses the JavaScript stack for generating data, but this is not a requirement. If you would like to add fixtures and would like to create them manually, or add an alternative mechanism for generating fixtures from source then please do so.
 
+## Negative Fixtures
+
+Separately to the _positive_ fixtures, there is a [negative-fixtures](./negative-fixtures/) directory that contains failure conditions for codecs. These don't require a compile step, so are not included in the _fixtures_src directory but are edited directly.
+
+The structure for negative fixtures subdirectories is: `negative-fixtures/<codec name>/{encode,decode}/<fixtures>.json`. Where `<codec name>` is the canonical name of the codec being tested. `encode` and `decode` are fixtures that test the encode and decode paths of a codec, and `<fixture>` is an arbitrary name containing one or more fixture within the JSON structure.
+
+Test runners will load as manu fixture files as exist in these subdirectories and extract and run the cases defined there.
+
+### Encode
+
+Negative fixtures for an encode phase involve defining a data model form that should cause an error when passed through an `Encode()` for that codec. The data model form is instantiated by running the fixture data through an existing IPLD codec's decoder (mostly DAG-JSON data embedded within the JSON fixture document) and then attempting to pass that data model form into the codec and inspecting the error. Error messages may or may not be matched in some way, depending on the complexity of the implementation—it is more important that a failure occur than the error is exact.
+
+### Decode
+
+Negative fixtures for a decode phase involve loading a block's bytes from a hex form from the fixture data and passing those bytes through a `Decode()` for that codec and inspecting the error. Error messages may or may not be matched in some way, depending on the complexity of the implementation—it is more important that a failure occur than the error is exact.
+
 ## Implementations & Codecs
 
 ### Go
 
 Fixtures are tested against the [go-ipld-prime](https://github.com/ipld/go-ipld-prime) stack:
 
-* DAG-JSON: [go-ipld-prime/codec/dagjson](https://pkg.go.dev/github.com/ipld/go-ipld-prime/codec/dagjson)
-* DAG-CBOR: [go-ipld-prime/codec/dagcbor](https://pkg.go.dev/github.com/ipld/go-ipld-prime/codec/dagcbor)
+* DAG-JSON: [github.com/ipld/go-ipld-prime/codec/dagjson](https://pkg.go.dev/github.com/ipld/go-ipld-prime/codec/dagjson)
+* DAG-CBOR: [github.com/ipld/go-ipld-prime/codec/dagcbor](https://pkg.go.dev/github.com/ipld/go-ipld-prime/codec/dagcbor)
+* DAG-PB:  [github.com/ipld/go-codec-dagpb](https://pkg.go.dev/github.com/ipld/go-codec-dagpb)
 
 ### JavaScript
 
@@ -37,6 +54,7 @@ Fixtures are tested against the [js-multiformats](https://github.com/multiformat
 
 * DAG-CBOR: [@ipld/dag-cbor](https://github.com/ipld/js-dag-cbor)
 * DAG-JSON: [@ipld/dag-json](https://github.com/ipld/js-dag-cbor)
+* DAG-PB: [@ipld/dag-pb](https://github.com/ipld/js-dag-pb)
 
 ### Rust
 

--- a/go/codecs_test.go
+++ b/go/codecs_test.go
@@ -1,25 +1,30 @@
 package codec_fixtures
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/multicodec"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 )
 
-func TestCodecs(t *testing.T) {
+func TestFixtures(t *testing.T) {
 	dirs, err := os.ReadDir("../fixtures/")
 	if err != nil {
 		t.Fatalf("failed to open fixtures dir: %v", err)
 	}
 
 	for _, dir := range dirs {
-		fixtureName := dir.Name()
 		if !dir.IsDir() {
 			continue
 		}
+		fixtureName := dir.Name()
 		if reason, blacklisted := FixtureBlacklist[fixtureName]; blacklisted {
 			fmt.Printf("Skipping fixture '%v': %v\n", fixtureName, reason)
 			continue
@@ -46,5 +51,81 @@ func verifyCid(t *testing.T, desc string, node ipld.Node, toEnc ipld.LinkPrototy
 	}
 	if !expected.Equals(actual) {
 		t.Fatalf("[%v] generated CID (%v) does not match expected (%v)", desc, expected.String(), actual.String())
+	}
+}
+
+func TestNegatigeFixtures(t *testing.T) {
+	dirs, err := os.ReadDir("../negative-fixtures/")
+	if err != nil {
+		t.Fatalf("failed to open negative fixtures dir: %v", err)
+	}
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
+		codecName := dir.Name()
+		t.Run(codecName, func(t *testing.T) {
+			t.Run("encode", func(t *testing.T) {
+				files, err := os.ReadDir(filepath.Join("../negative-fixtures/", codecName, "encode"))
+				if err != nil {
+					t.Fatalf("failed to open negative fixtures dir: %v", err)
+				}
+				for _, file := range files {
+					if file.IsDir() {
+						continue
+					}
+					fixtureData, err := os.ReadFile(filepath.Join("../negative-fixtures/", codecName, "encode", file.Name()))
+					if err != nil {
+						t.Fatalf("failed to read fixture data: %v", err)
+					}
+					var fixtures []negativeFixtureEncode
+					err = json.Unmarshal(fixtureData, &fixtures)
+					if err != nil {
+						t.Fatalf("failed to decode fixture data: %v", err)
+					}
+					for _, fixture := range fixtures {
+						fixtureName := fmt.Sprintf("%s/encode/%s", codecName, fixture.Name)
+						if reason, blacklisted := FixtureBlacklist[fixtureName]; blacklisted {
+							fmt.Printf("Skipping fixture '%v': %v\n", fixtureName, reason)
+							continue
+						}
+						t.Run(fixture.Name, testNegativeFixtureEncode(codecName, fixture))
+					}
+				}
+			})
+		})
+	}
+}
+
+// create a test function an individual negative test fixture for encode
+func testNegativeFixtureEncode(codecName string, fixture negativeFixtureEncode) func(t *testing.T) {
+	return func(t *testing.T) {
+		dagJsonDecoder, err := multicodec.DefaultRegistry.LookupDecoder(dagJsonLp.Codec)
+		if err != nil {
+			t.Fatalf("could not choose a dag-pb encoder: %v", err)
+		}
+
+		// construct the data model form to encode from the dag-json data in the fixture
+		nb := basicnode.Prototype.Any.NewBuilder()
+		byts, err := json.Marshal(fixture.DagJson)
+		if err != nil {
+			t.Fatalf("failed to encode dag-json fixture data")
+		}
+		dagJsonDecoder(nb, bytes.NewReader(byts))
+		node := nb.Build()
+
+		// look up encoder to test
+		encoder, err := linkSystem.EncoderChooser(codecs[codecName])
+		if err != nil {
+			t.Fatalf("could not choose an encoder: %v", err)
+		}
+
+		// encode, should error
+		var buf bytes.Buffer
+		err = encoder(node, &buf)
+		if err == nil {
+			t.Errorf("should error on encode")
+		}
+		// TODO: test the error messages in some form? may require Go specific messages in fixture data
 	}
 }

--- a/go/fixtures.go
+++ b/go/fixtures.go
@@ -120,3 +120,9 @@ type negativeFixtureEncode struct {
 	DagJson interface{} `json:"dag-json,omitempty"`
 	Error   string      `json:"error"`
 }
+
+type negativeFixtureDecode struct {
+	Name  string `json:"name"`
+	Hex   string `json:"hex"`
+	Error string `json:"error"`
+}

--- a/go/fixtures.go
+++ b/go/fixtures.go
@@ -114,3 +114,9 @@ func nodeToCid(lp ipld.LinkPrototype, node ipld.Node) (cid.Cid, error) {
 	}
 	return cidLink.Cid, nil
 }
+
+type negativeFixtureEncode struct {
+	Name    string      `json:"name"`
+	DagJson interface{} `json:"dag-json,omitempty"`
+	Error   string      `json:"error"`
+}

--- a/go/special_cases.go
+++ b/go/special_cases.go
@@ -4,7 +4,9 @@ type FixtureName = string
 type FixtureBlacklistReason = string
 
 var FixtureBlacklist = map[FixtureName]FixtureBlacklistReason{
-	"int--11959030306112471732": "integer out of int64 range",
-	"int-11959030306112471731":  "integer out of int64 range",
-	"int-18446744073709551615":  "integer out of int64 range",
+	"int--11959030306112471732":            "integer out of int64 range",
+	"int-11959030306112471731":             "integer out of int64 range",
+	"int-18446744073709551615":             "integer out of int64 range",
+	"dag-pb/encode/bad sort":               "pre-sort not required",
+	"dag-pb/encode/bad sort (incl length)": "pre-sort not required",
 }

--- a/js/test.js
+++ b/js/test.js
@@ -11,6 +11,7 @@ import {
   negativeFixturesDecode,
   loadFixture
 } from './util.js'
+import { bytes } from 'multiformats'
 
 const { assert } = chai
 const utfEncoder = new TextEncoder()
@@ -33,7 +34,8 @@ describe('Codec fixtures', () => {
 describe.only('Codec negative fixtures', () => {
   for (const codec of negativeFixtureCodecs()) {
     describe(codec, () => {
-      const { encode } = codecs[codec].codec
+      const { encode, decode } = codecs[codec].codec
+
       for (const fixtures of negativeFixturesEncode(codec)) {
         for (const fixture of fixtures) {
           it(fixture.name, () => {
@@ -48,6 +50,20 @@ describe.only('Codec negative fixtures', () => {
               assert.fail('did not error')
             } catch (e) {
               assert.strictEqual(e.message, error)
+            }
+          })
+        }
+      }
+
+      for (const fixtures of negativeFixturesDecode(codec)) {
+        for (const { name, hex, error } of fixtures) {
+          it(name, () => {
+            const byts = bytes.fromHex(hex)
+            try {
+              decode(byts)
+              assert.fail('did not error')
+            } catch (e) {
+              assert.strictEqual(e.message.replace(/^protobuf: \(PBNode\) /, ''), error)
             }
           })
         }

--- a/js/test.js
+++ b/js/test.js
@@ -4,9 +4,16 @@ import chai from 'chai'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as Block from 'multiformats/block'
 import { codecs } from './codecs.js'
-import { fixtureDirectories, loadFixture } from './util.js'
+import {
+  fixtureDirectories,
+  negativeFixtureCodecs,
+  negativeFixturesEncode,
+  negativeFixturesDecode,
+  loadFixture
+} from './util.js'
 
 const { assert } = chai
+const utfEncoder = new TextEncoder()
 
 describe('Codec fixtures', () => {
   for (const { name, url } of fixtureDirectories()) {
@@ -17,6 +24,32 @@ describe('Codec fixtures', () => {
         for (const [toCodec, { cid }] of Object.entries(data)) {
           const block = await Block.encode({ value, codec: codecs[toCodec].codec, hasher: sha256 })
           assert.equal(block.cid.toString(), cid, `CIDs match for data decoded from ${fromCodec} encoded as ${toCodec}`)
+        }
+      }
+    })
+  }
+})
+
+describe.only('Codec negative fixtures', () => {
+  for (const codec of negativeFixtureCodecs()) {
+    describe(codec, () => {
+      const { encode } = codecs[codec].codec
+      for (const fixtures of negativeFixturesEncode(codec)) {
+        for (const fixture of fixtures) {
+          it(fixture.name, () => {
+            const { name, error } = fixture
+            if (!'dag-json' in fixture) {
+              // TODO: when we need it, probably hex decode for others
+              assert.fail('can\'t deal with fixture that doesn\'t have dag-json input')
+            }
+            const obj = codecs['dag-json'].codec.decode(utfEncoder.encode(JSON.stringify(fixture['dag-json'])))
+            try {
+              encode(obj)
+              assert.fail('did not error')
+            } catch (e) {
+              assert.strictEqual(e.message, error)
+            }
+          })
         }
       }
     })

--- a/js/util.js
+++ b/js/util.js
@@ -2,6 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 export const fixturesDir = new URL('../fixtures/', import.meta.url)
+export const negativeFixturesDir = new URL('../negative-fixtures/', import.meta.url)
 
 export async function loadFixture (dir) {
   const data = {}
@@ -14,13 +15,45 @@ export async function loadFixture (dir) {
   return data
 }
 
-export function * fixtureDirectories () {
-  for (const name of fs.readdirSync(fixturesDir)) {
-    const stat = fs.statSync(new URL(`./${name}`, fixturesDir))
-    if (!stat.isDirectory()) {
+function * iterate (type, ...dirs) {
+  let part = `.`
+  if (dirs.length > 1) {
+    part = `${part}/${dirs.slice(1).join('/')}/`
+  }
+  const base = new URL(part, dirs[0])
+  for (const name of fs.readdirSync(base)) {
+    let url = new URL(`./${name}`, base)
+    const stat = fs.statSync(url)
+    if ((type === 'dir' && !stat.isDirectory()) || (type === 'file' && stat.isDirectory())) {
       continue
     }
-    const url = new URL(`./${name}/`, fixturesDir)
+    if (type === 'dir') {
+      url = new URL(`./${name}/`, base)
+    }
     yield { name, url }
+  }
+}
+
+export function * fixtureDirectories () {
+  yield * iterate('dir', fixturesDir)
+}
+
+export function * negativeFixtureCodecs () {
+  for (const { name } of iterate('dir', negativeFixturesDir)) {
+    yield name
+  }
+}
+
+export function * negativeFixturesEncode (codec) {
+  for (const { name, url } of iterate('file', negativeFixturesDir, codec, 'encode')) {
+    const fixtureText = fs.readFileSync(url, 'utf8')
+    yield JSON.parse(fixtureText)
+  }
+}
+
+export function * negativeFixturesDecode (codec) {
+  for (const { name, url } of iterate('file', negativeFixturesDir, codec, 'decode')) {
+    const fixtureText = fs.readFileSync(url, 'utf8')
+    yield JSON.parse(fixtureText)
   }
 }

--- a/js/util.js
+++ b/js/util.js
@@ -44,16 +44,17 @@ export function * negativeFixtureCodecs () {
   }
 }
 
-export function * negativeFixturesEncode (codec) {
-  for (const { name, url } of iterate('file', negativeFixturesDir, codec, 'encode')) {
+export function * negativeFixtures (type, codec) {
+  for (const { name, url } of iterate('file', negativeFixturesDir, codec, type)) {
     const fixtureText = fs.readFileSync(url, 'utf8')
     yield JSON.parse(fixtureText)
   }
 }
 
+export function * negativeFixturesEncode (codec) {
+  yield * negativeFixtures('encode', codec)
+}
+
 export function * negativeFixturesDecode (codec) {
-  for (const { name, url } of iterate('file', negativeFixturesDir, codec, 'decode')) {
-    const fixtureText = fs.readFileSync(url, 'utf8')
-    yield JSON.parse(fixtureText)
-  }
+  yield * negativeFixtures('decode', codec)
 }

--- a/negative-fixtures/dag-pb/decode/edges.json
+++ b/negative-fixtures/dag-pb/decode/edges.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "Link with no Hash",
+    "hex": "1200",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Data, and Link with no Hash",
+    "hex": "12000a050001020304",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with zero Hash",
+    "hex": "12020a00",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with just Name",
+    "hex": "12021200",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with just empty Name",
+    "hex": "12021200",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with just some Name",
+    "hex": "120b1209736f6d65206e616d65",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with just zero Tsize",
+    "hex": "12021800",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "Link with just nonzero Tsize",
+    "hex": "120318f207",
+    "error": "Invalid Hash field found in link, expected CID"
+  },
+  {
+    "name": "data between links",
+    "hex": "12240a221220cf92fdefcdc34cac009c8b05eb662be0618db9de55ecd42785e9ec6712f8df650a040802180612240a221220cf92fdefcdc34cac009c8b05eb662be0618db9de55ecd42785e9ec6712f8df65",
+    "error": "duplicate Links section"
+  }
+]

--- a/negative-fixtures/dag-pb/encode/basic-datamodel-kinds.json
+++ b/negative-fixtures/dag-pb/encode/basic-datamodel-kinds.json
@@ -1,0 +1,63 @@
+[
+  {
+    "name": "true",
+    "dag-json": true,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "false",
+    "dag-json": false,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "null",
+    "dag-json": null,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "int (0)",
+    "dag-json": 0,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "int (101)",
+    "dag-json": 101,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "int (-101)",
+    "dag-json": -101,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "float (1.1)",
+    "dag-json": 1.1,
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "string",
+    "dag-json": "blip",
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "list",
+    "dag-json": [],
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "bytes",
+    "dag-json": {
+      "/": {
+        "bytes": "AQID"
+      }
+    },
+    "error": "Invalid DAG-PB form"
+  },
+  {
+    "name": "link",
+    "dag-json": {
+      "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+    },
+    "error": "Invalid DAG-PB form"
+  }
+]

--- a/negative-fixtures/dag-pb/encode/invalid-forms.json
+++ b/negative-fixtures/dag-pb/encode/invalid-forms.json
@@ -1,0 +1,747 @@
+[
+  {
+    "name": "empty map",
+    "dag-json": {},
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "Data and Links null",
+    "dag-json": {
+      "Data": null,
+      "Links": null
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "Data null, Links empty",
+    "dag-json": {
+      "Data": null,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "Links null",
+    "dag-json": {
+      "Links": null
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "empty Link",
+    "dag-json": {
+      "Links": [
+        {}
+      ]
+    },
+    "error": "Invalid DAG-PB form (link must have a Hash)"
+  },
+  {
+    "name": "some Data, empty Link",
+    "dag-json": {
+      "Data": {
+        "/": {
+          "bytes": "AQID"
+        }
+      },
+      "Links": [
+        {}
+      ]
+    },
+    "error": "Invalid DAG-PB form (link must have a Hash)"
+  },
+  {
+    "name": "extraneous field",
+    "dag-json": {
+      "Data": {
+        "/": {
+          "bytes": "AQID"
+        }
+      },
+      "extraneous": true
+    },
+    "error": "Invalid DAG-PB form (extraneous properties)"
+  },
+  {
+    "name": "extraneous Links field",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "extraneous": true
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (extraneous properties on link)"
+  },
+  {
+    "name": "bad Data type (null)",
+    "dag-json": {
+      "Data": null,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (true)",
+    "dag-json": {
+      "Data": true,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (false)",
+    "dag-json": {
+      "Data": false,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (int 0)",
+    "dag-json": {
+      "Data": 0,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (int 101)",
+    "dag-json": {
+      "Data": 101,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (int -101)",
+    "dag-json": {
+      "Data": -101,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (float 1.1)",
+    "dag-json": {
+      "Data": 1.1,
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (list)",
+    "dag-json": {
+      "Data": [],
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Data type (map)",
+    "dag-json": {
+      "Data": {},
+      "Links": []
+    },
+    "error": "Invalid DAG-PB form (Data must be bytes)"
+  },
+  {
+    "name": "bad Links type (null)",
+    "dag-json": {
+      "Links": null
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (true)",
+    "dag-json": {
+      "Links": true
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (false)",
+    "dag-json": {
+      "Links": false
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (int 0)",
+    "dag-json": {
+      "Links": 0
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (int 101)",
+    "dag-json": {
+      "Links": 101
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (int -101)",
+    "dag-json": {
+      "Links": -101
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (float 1.1)",
+    "dag-json": {
+      "Links": 1.1
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (string)",
+    "dag-json": {
+      "Links": "blip"
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Links type (map)",
+    "dag-json": {
+      "Links": {}
+    },
+    "error": "Invalid DAG-PB form (Links must be a list)"
+  },
+  {
+    "name": "bad Link type (null)",
+    "dag-json": {
+      "Links": [
+        null
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (true)",
+    "dag-json": {
+      "Links": [
+        true
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (false)",
+    "dag-json": {
+      "Links": [
+        false
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (int 0)",
+    "dag-json": {
+      "Links": [
+        0
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (int 101)",
+    "dag-json": {
+      "Links": [
+        101
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (int -101)",
+    "dag-json": {
+      "Links": [
+        -101
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (float)",
+    "dag-json": {
+      "Links": [
+        1.1
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (string)",
+    "dag-json": {
+      "Links": [
+        "blip"
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (bytes)",
+    "dag-json": {
+      "Links": [
+        {
+          "/": {
+            "bytes": "AQID"
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link type (link)",
+    "dag-json": {
+      "Links": [
+        {
+          "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (bad link)"
+  },
+  {
+    "name": "bad Link, only Name",
+    "dag-json": {
+      "Links": [
+        {
+          "Name": "blip"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link must have a Hash)"
+  },
+  {
+    "name": "bad Link, only Tsize",
+    "dag-json": {
+      "Links": [
+        {
+          "Tsize": 101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link must have a Hash)"
+  },
+  {
+    "name": "bad Link, only Name and Tsize",
+    "dag-json": {
+      "Links": [
+        {
+          "Name": "blip",
+          "Tsize": 101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link must have a Hash)"
+  },
+  {
+    "name": "bad Link.Hash type (null)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": null
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (true)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": true
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (false)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": false
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (int 0)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": 0
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (int 101)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": 101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (int -101)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": -101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (float)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": 1.1
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (string)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": "blip"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Hash type (bytes)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": {
+              "bytes": "8AECAwQ"
+            }
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Hash must be a CID)"
+  },
+  {
+    "name": "bad Link.Name type (null)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": null
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (true)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": true
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (false)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": false
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (int 0)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": 0
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (int 101)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": 101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (int -101)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": -101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (float)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": 1.1
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (bytes)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": {
+            "/": {
+              "bytes": "AQID"
+            }
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Name type (link)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Name must be a string)"
+  },
+  {
+    "name": "bad Link.Tsize type (null)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": null
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (true)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": true
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (false)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": false
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (int negative)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": -101
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize cannot be negative)"
+  },
+  {
+    "name": "bad Link.Tsize type (float)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": 1.1
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (string)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": "blip"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (bytes)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": {
+            "/": {
+              "bytes": "AQID"
+            }
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad Link.Tsize type (link)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Tsize": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          }
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (link Tsize must be an integer)"
+  },
+  {
+    "name": "bad sort",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          }
+        },
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": "foo"
+        },
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": "bar"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (links must be sorted by Name bytes)"
+  },
+  {
+    "name": "bad sort (incl length)",
+    "dag-json": {
+      "Links": [
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          }
+        },
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": "aa"
+        },
+        {
+          "Hash": {
+            "/": "QmNPWHBrVQiiV8FpyNuEPhB9E2rbvdy9Yx79EY1EJuyf9o"
+          },
+          "Name": "a"
+        }
+      ]
+    },
+    "error": "Invalid DAG-PB form (links must be sorted by Name bytes)"
+  }
+]


### PR DESCRIPTION
_Finally_ this closes #80.

* Negative fixtures framework in JS & Go for running `decode()` operations and checking failure conditions - blocks are defined in hex within the fixture docs.
* Negative fixtures framework in JS & Go for running `encode()` operations and checking failure conditions - the JSON files containing the fixtures define a data model form in an existing codec that can be decoded (currently only dag-json, just plainly presented inside the JSON, but this will likely need to be extended to present a hex form for other codecs so there's optionality), then that data model form is passed through the codec's encoder and error is checked
* Docs
* Fixtures for encode and decode for dag-pb, extracted from the common tests that I've built up for both current JS & Go implementations.

No Rust yet; but I'd really love to get these in and expanded: dag-pb mainly for Iroh and dag-cbor mainly for FVM.

* [ ] I need to "fix" the JS dag-pb's error messages to match what I have here, it highlighted some inconsistencies and a bit of sloppiness, will do a PR over there following this.