### PR TITLE
feat: add negative test fixtures to Rust

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,6 +3,7 @@ name = "codec-fixtures"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+[dev-dependencies]
+hex = "0.4.3"
 libipld = { version = "*", features = ["serde-codec"] }
 serde_ipld_dagcbor = "*"

--- a/rust/Cargo_latest_git.toml
+++ b/rust/Cargo_latest_git.toml
@@ -3,6 +3,7 @@ name = "codec-fixtures"
 version = "0.1.0"
 edition = "2021"
 
-[dependencies]
+[dev-dependencies]
+hex = "0.4.3"
 libipld = { git = "https://github.com/ipld/libipld", features = ["serde-codec"] }
 serde_ipld_dagcbor = { git = "https://github.com/ipld/serde_ipld_dagcbor" }

--- a/rust/tests/codecs.rs
+++ b/rust/tests/codecs.rs
@@ -1,6 +1,4 @@
-use std::env;
-use std::fs::{self, DirEntry};
-use std::path::PathBuf;
+mod utils;
 
 use libipld::{
     cid::Cid,
@@ -9,54 +7,6 @@ use libipld::{
     multihash::{Code, MultihashDigest},
     IpldCodec,
 };
-
-static FIXTURE_SKIPLIST: [(&str, &str); 16] = [
-    ("int--11959030306112471732", "integer out of int64 range"),
-    (
-        "dagpb_11unnamedlinks+data",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    ("dagpb_1link", "DAG-PB isn't fully compatible yet"),
-    ("dagpb_2link+data", "DAG-PB isn't fully compatible yet"),
-    (
-        "dagpb_4namedlinks+data",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    (
-        "dagpb_7unnamedlinks+data",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    ("dagpb_Data_zero", "DAG-PB isn't fully compatible yet"),
-    ("dagpb_empty", "DAG-PB isn't fully compatible yet"),
-    ("dagpb_Links_Hash_some", "DAG-PB isn't fully compatible yet"),
-    (
-        "dagpb_Links_Hash_some_Name_some",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    (
-        "dagpb_Links_Hash_some_Name_zero",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    (
-        "dagpb_Links_Hash_some_Tsize_some",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    (
-        "dagpb_Links_Hash_some_Tsize_zero",
-        "DAG-PB isn't fully compatible yet",
-    ),
-    ("dagpb_simple_forms_2", "DAG-PB isn't fully compatible yet"),
-    ("dagpb_simple_forms_3", "DAG-PB isn't fully compatible yet"),
-    ("dagpb_simple_forms_4", "DAG-PB isn't fully compatible yet"),
-];
-
-/// Contents of a single fixture.
-#[derive(Debug)]
-struct Fixture {
-    codec: String,
-    cid: Cid,
-    bytes: Vec<u8>,
-}
 
 /// Mapping between string identifiers and actual codecs.
 struct Codecs;
@@ -73,73 +23,10 @@ impl Codecs {
     }
 }
 
-/// Returns all fixtures from a directory.
-fn load_fixture(dir: DirEntry) -> Vec<Fixture> {
-    fs::read_dir(&dir.path())
-        .unwrap()
-        .filter_map(|file| {
-            // Filter out invalid files.
-            let file = file.ok()?;
-
-            let path = file.path();
-            let extension = path
-                .extension()
-                .expect("Filename must have an extension")
-                .to_os_string()
-                .into_string()
-                .expect("Extension must be valid UTF-8");
-            let cid = path
-                .file_stem()
-                .expect("Filename must have a name")
-                .to_os_string()
-                .into_string()
-                .expect("Filename must be valid UTF-8");
-            let bytes = fs::read(&path).expect("File must be able to be read");
-
-            Some(Fixture {
-                codec: extension,
-                cid: Cid::try_from(cid.clone()).expect("Filename must be a valid Cid"),
-                bytes,
-            })
-        })
-        .collect()
-}
-
-/// Returns the paths to all directories that contain fixtures.
-fn fixture_directories() -> Vec<DirEntry> {
-    let rust_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set");
-    let mut fixtures_dir = PathBuf::from(rust_dir);
-    fixtures_dir.push("../fixtures");
-
-    // Only take directories, exclude files
-    fs::read_dir(&fixtures_dir)
-        .expect("Cannot open fixtures directory")
-        .filter_map(Result::ok)
-        .filter(|dir| dir.path().is_dir())
-        .collect()
-}
-
-/// Returns true if a test fixture is on the skip list
-fn skip_test(dir: &DirEntry) -> bool {
-    for (name, reason) in FIXTURE_SKIPLIST {
-        if dir
-            .path()
-            .into_os_string()
-            .to_str()
-            .unwrap()
-            .ends_with(name)
-        {
-            eprintln!("Skipping fixture '{}': {}", name, reason);
-            return true;
-        }
-    }
-    false
-}
-
 #[test]
 fn codec_fixtures() {
-    for dir in fixture_directories() {
-        if skip_test(&dir) {
+    for dir in utils::fixture_directories("fixtures") {
+        if utils::skip_test(&dir) {
             continue;
         }
 
@@ -149,10 +36,10 @@ fn codec_fixtures() {
             .expect("Directory must have a name")
             .to_os_string()
             .to_str()
-            .expect("Filenome must be valid UTF-8")
+            .expect("Filename must be valid UTF-8")
             .to_string();
         println!("Testing fixture {}", fixture_name);
-        let fixtures = load_fixture(dir);
+        let fixtures = utils::load_fixtures(dir);
         for from_fixture in &fixtures {
             // Take a fixture of one codec and…
             let decoded: Ipld = Codecs::get(&from_fixture.codec)
@@ -170,6 +57,42 @@ fn codec_fixtures() {
                     "CIDs match for the data decoded from {} encoded as {}",
                     from_fixture.codec, to_fixture.codec
                 );
+            }
+        }
+    }
+}
+
+#[test]
+fn negative_fixtures() {
+    for codec_dir in utils::fixture_directories("negative-fixtures") {
+        let codec_name = codec_dir
+            .file_name()
+            .to_str()
+            .expect("Codec names are valid UTF-8")
+            .to_string();
+        let codec = Codecs::get(&codec_name);
+
+        let encode_fixtures = utils::load_negative_fixtures(codec_dir.path(), "encode");
+        for fixture in encode_fixtures {
+            println!(
+                "Testing negative encode fixture for {}: {}",
+                codec_name, fixture.name
+            );
+            match codec.encode(&fixture.dag_json.unwrap()) {
+                Ok(_) => assert!(false, "did not error"),
+                Err(_) => assert!(true),
+            }
+        }
+
+        let decode_fixtures = utils::load_negative_fixtures(codec_dir.path(), "decode");
+        for fixture in decode_fixtures {
+            println!(
+                "Testing negative decode fixture for {}: {}",
+                codec_name, fixture.name
+            );
+            match codec.decode::<Ipld>(&fixture.hex.unwrap()) {
+                Ok(_) => assert!(false, "did not error"),
+                Err(_) => assert!(true),
             }
         }
     }

--- a/rust/tests/utils.rs
+++ b/rust/tests/utils.rs
@@ -1,0 +1,139 @@
+use std::env;
+use std::fs::{self, DirEntry};
+use std::path::PathBuf;
+
+use libipld::{cid::Cid, codec::Codec, ipld::Ipld, IpldCodec};
+
+static FIXTURE_SKIPLIST: [(&str, &str); 1] =
+    [("int--11959030306112471732", "integer out of int64 range")];
+
+/// Contents of a single fixture.
+#[derive(Debug)]
+pub struct Fixture {
+    pub codec: String,
+    pub cid: Cid,
+    pub bytes: Vec<u8>,
+}
+
+/// Contents of a single negative fixture.
+#[derive(Debug)]
+pub struct NegativeFixture {
+    pub name: String,
+    /// Negative decode fixtures use hex values.
+    pub hex: Option<Vec<u8>>,
+    /// Negative encode fixtures use DAG-JSON values.
+    pub dag_json: Option<Ipld>,
+}
+
+/// Returns all fixtures from a directory.
+pub fn load_fixtures(dir: DirEntry) -> Vec<Fixture> {
+    fs::read_dir(&dir.path())
+        .unwrap()
+        .filter_map(|file| {
+            // Filter out invalid files.
+            let file = file.ok()?;
+
+            let path = file.path();
+            let extension = path
+                .extension()
+                .expect("Filename must have an extension")
+                .to_os_string()
+                .into_string()
+                .expect("Extension must be valid UTF-8");
+            let cid = path
+                .file_stem()
+                .expect("Filename must have a name")
+                .to_os_string()
+                .into_string()
+                .expect("Filename must be valid UTF-8");
+            let bytes = fs::read(&path).expect("File must be able to be read");
+
+            Some(Fixture {
+                codec: extension,
+                cid: Cid::try_from(cid.clone()).expect("Filename must be a valid Cid"),
+                bytes,
+            })
+        })
+        .collect()
+}
+
+/// Returns the paths to all directories that contain fixtures.
+pub fn fixture_directories(name: &str) -> Vec<DirEntry> {
+    let rust_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set");
+    let mut fixtures_dir = PathBuf::from(rust_dir);
+    fixtures_dir.push(format!("../{}", name));
+
+    // Only take directories, exclude files
+    fs::read_dir(&fixtures_dir)
+        .expect("Cannot open fixtures directory")
+        .filter_map(Result::ok)
+        .filter(|dir| dir.path().is_dir())
+        .collect()
+}
+
+/// Returns true if a test fixture is on the skip list
+pub fn skip_test(dir: &DirEntry) -> bool {
+    for (name, reason) in FIXTURE_SKIPLIST {
+        if dir
+            .path()
+            .into_os_string()
+            .to_str()
+            .unwrap()
+            .ends_with(name)
+        {
+            eprintln!("Skipping fixture '{}': {}", name, reason);
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns all test fixtures from the given directory.
+///
+/// `en_or_decode` specifies the directory name for encode/decode fixtures, hence should either be
+/// `encode` or `decode`
+pub fn load_negative_fixtures(mut dir: PathBuf, en_or_decode: &str) -> Vec<NegativeFixture> {
+    dir.push(en_or_decode);
+    if let Ok(read_dir) = fs::read_dir(&dir) {
+        read_dir
+            .filter_map(|file| {
+                // Filter out invalid files.
+                let file = file.ok()?;
+
+                let path = file.path();
+                let bytes = fs::read(&path).expect("File must be able to be read");
+                // Use DAG-JSON for parsing, so we don't need and extra JSON parser.
+                let ipld: Ipld = IpldCodec::DagJson.decode(&bytes).expect("It's valid JSON");
+
+                if let Ipld::List(list) = ipld {
+                    let fixtures: Vec<_> = list
+                        .iter()
+                        .map(|fixture| {
+                            if let Ok(Ipld::String(name)) = fixture.get("name") {
+                                let dag_json = fixture.get("dag-json").ok().cloned();
+                                let hex = if let Ok(Ipld::String(data)) = fixture.get("hex") {
+                                    Some(hex::decode(data).unwrap())
+                                } else {
+                                    None
+                                };
+                                NegativeFixture {
+                                    name: name.to_string(),
+                                    hex,
+                                    dag_json,
+                                }
+                            } else {
+                                panic!("Negative fixture has no name");
+                            }
+                        })
+                        .collect();
+                    Some(fixtures)
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect()
+    } else {
+        Vec::new()
+    }
+}


### PR DESCRIPTION
Also run the negative test fixtures on the Rust implementations.

This commit also upgrades to the newest version of libipld, which now passes all DAG-PB fixtures, except for the integer out of i64 range one.

It also refactors the code a bit, so that the libipld codecs and
the Serde based ones share more of the code.

Supersedes #78.