### PR TITLE
fix: Rust: skip fixture for DAG-JSON only

### DIFF
--- a/rust/tests/codecs.rs
+++ b/rust/tests/codecs.rs
@@ -26,10 +26,6 @@ impl Codecs {
 #[test]
 fn codec_fixtures() {
     for dir in utils::fixture_directories("fixtures") {
-        if utils::skip_test(&dir) {
-            continue;
-        }
-
         let fixture_name = dir
             .path()
             .file_stem()
@@ -39,8 +35,12 @@ fn codec_fixtures() {
             .expect("Filename must be valid UTF-8")
             .to_string();
         println!("Testing fixture {}", fixture_name);
-        let fixtures = utils::load_fixtures(dir);
+        let fixtures = utils::load_fixtures(&dir);
         for from_fixture in &fixtures {
+            if utils::skip_test(&dir, &from_fixture.codec) {
+                continue;
+            }
+
             // Take a fixture of one codec and…
             let decoded: Ipld = Codecs::get(&from_fixture.codec)
                 .decode(&from_fixture.bytes)
@@ -48,6 +48,10 @@ fn codec_fixtures() {
 
             // …transcode it into any other fixture.
             for to_fixture in &fixtures {
+                if utils::skip_test(&dir, &to_fixture.codec) {
+                    continue;
+                }
+
                 let codec = Codecs::get(&to_fixture.codec);
                 let data = codec.encode(&decoded).expect("Encoding must work");
                 let digest = Code::Sha2_256.digest(&data);

--- a/rust/tests/serde.rs
+++ b/rust/tests/serde.rs
@@ -27,10 +27,6 @@ impl Codecs {
 #[test]
 fn codec_fixtures() {
     for dir in utils::fixture_directories("fixtures") {
-        if utils::skip_test(&dir) {
-            continue;
-        }
-
         let fixture_name = dir
             .path()
             .file_stem()
@@ -40,8 +36,12 @@ fn codec_fixtures() {
             .expect("Filename must be valid UTF-8")
             .to_string();
         println!("Testing fixture {}", fixture_name);
-        let fixtures = utils::load_fixtures(dir);
+        let fixtures = utils::load_fixtures(&dir);
         for from_fixture in &fixtures {
+            if utils::skip_test(&dir, &from_fixture.codec) {
+                continue;
+            }
+
             // Take a fixture of one codec and…
             let decoded: Ipld = match &from_fixture.codec[..] {
                 "dag-cbor" => {
@@ -54,6 +54,10 @@ fn codec_fixtures() {
 
             // …transcode it into any other fixture.
             for to_fixture in &fixtures {
+                if utils::skip_test(&dir, &to_fixture.codec) {
+                    continue;
+                }
+
                 let (codec_code, data) = match &to_fixture.codec[..] {
                     "dag-cbor" => (
                         0x71,

--- a/rust/tests/utils.rs
+++ b/rust/tests/utils.rs
@@ -4,8 +4,14 @@ use std::path::PathBuf;
 
 use libipld::{cid::Cid, codec::Codec, ipld::Ipld, IpldCodec};
 
-static FIXTURE_SKIPLIST: [(&str, &str); 1] =
-    [("int--11959030306112471732", "integer out of int64 range")];
+static FIXTURE_SKIPLIST: [(&str, &str, &str); 1] = [
+    // This test is skipped as the current DAG-JSON decoder decodes such an integer into a float.
+    (
+        "dag-json",
+        "int--11959030306112471732",
+        "integer out of int64 range",
+    ),
+];
 
 /// Contents of a single fixture.
 #[derive(Debug)]
@@ -26,7 +32,7 @@ pub struct NegativeFixture {
 }
 
 /// Returns all fixtures from a directory.
-pub fn load_fixtures(dir: DirEntry) -> Vec<Fixture> {
+pub fn load_fixtures(dir: &DirEntry) -> Vec<Fixture> {
     fs::read_dir(&dir.path())
         .unwrap()
         .filter_map(|file| {
@@ -72,16 +78,17 @@ pub fn fixture_directories(name: &str) -> Vec<DirEntry> {
 }
 
 /// Returns true if a test fixture is on the skip list
-pub fn skip_test(dir: &DirEntry) -> bool {
-    for (name, reason) in FIXTURE_SKIPLIST {
-        if dir
-            .path()
-            .into_os_string()
-            .to_str()
-            .unwrap()
-            .ends_with(name)
+pub fn skip_test(dir: &DirEntry, codec: &str) -> bool {
+    for (skip_codec, name, reason) in FIXTURE_SKIPLIST {
+        if codec == skip_codec
+            && dir
+                .path()
+                .into_os_string()
+                .to_str()
+                .unwrap()
+                .ends_with(name)
         {
-            eprintln!("Skipping fixture '{}': {}", name, reason);
+            eprintln!("Skipping {} fixture '{}': {}", codec, name, reason);
             return true;
         }
     }


### PR DESCRIPTION
The Rust DAG-JSON codec currently does decode integers smaller than `i64::MIN` as floats. Therefore it cannot be used for testing encoding round-trips.

The DAG-CBOR implementations works with integers smaller than `i64:MIN`, hence their tests are run.